### PR TITLE
update Open Rodent's Revenge license, platforms and dependencies

### DIFF
--- a/games/open_rodents_revenge.md
+++ b/games/open_rodents_revenge.md
@@ -5,11 +5,11 @@ _Remake of Rodent's Revenge._
 - Home: https://github.com/pierreyoda/o2r, https://sourceforge.net/projects/o2r/
 - State: beta, inactive since 2018
 - Download: https://github.com/pierreyoda/o2r/releases, https://sourceforge.net/projects/o2r/files/
-- Platform: Windows
+- Platform: Windows, Linux, macOS
 - Keywords: remake, inspired by Rodent's Revenge
 - Code repository: https://github.com/pierreyoda/o2r.git, https://svn.code.sf.net/p/o2r/code/ (svn)
 - Code language: C++
-- Code license: GPL-3.0
-- Code dependencies: SFML
+- Code license: MIT
+- Code dependencies: Qt, SFML
 
 ## Building


### PR DESCRIPTION
Hey, thanks for the awesome resource!

This is just a quick PR to update Open Rodent's Revenge entry as it has switched to the MIT license since.

Also, Qt was missing from the code dependencies list. Since I used SFML for the game proper, it is effectively cross-platform even though I never provided builds for macOS.

I wish I could write build instructions but the C++ and especially Qt build tooling and practices have changed quite a bit in the last couple of years. I do know that the master can easily build on recent Qt Creator versions but not sure about the 0.7 and previous releases.