### PR TITLE
Add 2009scape

### DIFF
--- a/code/archives.json
+++ b/code/archives.json
@@ -1270,6 +1270,7 @@
   "https://gitlab.com/KilgoreTroutMaskReplicant/1oom.git",
   "https://gitlab.com/LibreGames/freesiege.git",
   "https://gitlab.com/SuperTuxParty/SuperTuxParty.git",
+  "https://gitlab.com/2009scape/2009scape.git",
   "https://gitlab.com/alaskalinuxuser/app_critical_velocity.git",
   "https://gitlab.com/andybalaam/cross-the-road.git",
   "https://gitlab.com/andybalaam/duckmaze.git",

--- a/entries/2009scape.md
+++ b/entries/2009scape.md
@@ -1,0 +1,20 @@
+# 2009scape
+
+- Home: https://2009scape.org/
+- Media: https://en.wikipedia.org/wiki/0_A.D._(video_game)
+- Inspiration: RuneScape
+- State: beta
+- Download: https://play0ad.com/download/
+- Platform: Windows, Linux, macOS
+- Keyword: remake, role playing, content commercial, multiplayer online + co-op
+- Code repository: https://gitlab.com/2009scape/2009scape (@created 2017, @stars 18, @forks 37)
+- Code language: Java
+- Code license: AGPL
+- Code dependency: Java
+- Assets license: CC-BY-SA-3.0
+- Developer: ceikry, skelsoft, Badhad, Avi Weinstock, Woahscam, Von Hresvelg, downthecrop, phil lips, NixWigton, vk, Kermit Frog
+
+## Building
+
+- Build system: Gradle
+

--- a/entries/2009scape.md
+++ b/entries/2009scape.md
@@ -3,8 +3,8 @@
 - Home: https://2009scape.org/
 - Media: https://en.wikipedia.org/wiki/0_A.D._(video_game)
 - Inspiration: RuneScape
-- State: beta
-- Download: https://play0ad.com/download/
+- State: complete
+- Download: https://2009scape.org/
 - Platform: Windows, Linux, macOS
 - Keyword: remake, role playing, content commercial, multiplayer online + co-op
 - Code repository: https://gitlab.com/2009scape/2009scape (@created 2017, @stars 18, @forks 37)

--- a/entries/2009scape.md
+++ b/entries/2009scape.md
@@ -11,7 +11,6 @@
 - Code language: Java
 - Code license: AGPL
 - Code dependency: Java
-- Assets license: CC-BY-SA-3.0
 - Developer: ceikry, skelsoft, Badhad, Avi Weinstock, Woahscam, Von Hresvelg, downthecrop, phil lips, NixWigton, vk, Kermit Frog
 
 ## Building


### PR DESCRIPTION
https://2009scape.org/ is in a playable state, the repo moved to Gitlab some time ago and lost a lot of OG contributors so the contributor list is only people who have helped in the past 2 or so yrs