### PR TITLE
Add Cube

### DIFF
--- a/developers.md
+++ b/developers.md
@@ -61617,6 +61617,12 @@
 - Contact: wooferzfg@GH
 - Home: https://www.wooferzfg.me
 
+## Wouter van Oortmerssen [1]
+
+- Games: Cube
+- Contact: aardappel@GH, aardappel@SF
+- Home: https://strlen.com/
+
 ## Woox [1]
 
 - Games: RuneLite

--- a/entries/cube.md
+++ b/entries/cube.md
@@ -1,0 +1,17 @@
+# Cube
+
+- Home: http://cubeengine.com/cube.php, https://sourceforge.net/projects/cube/
+- Media: https://en.wikipedia.org/wiki/Cube_(video_game)
+- State: mature, inactive since 2005
+- Download: https://sourceforge.net/projects/cube/files/cube/
+- Platform: Windows, Linux, macOS
+- Keyword: action, first-person, shooter
+- Code repository: https://sourceforge.net/projects/cube/files/cube/2005_08_29/cube_2005_08_29_src_zlib.zip/download
+- Code language: C, C++
+- Code license: Custom (zlib like)
+- Code dependency: SDL
+- Developer: Wouter van Oortmerssen
+
+## Building
+
+- Build system: Make, Visual Studio


### PR DESCRIPTION
Adds [Cube](https://en.wikipedia.org/wiki/Cube_(video_game)), the game that spawned the Cube engine family.

I could not locate a repository, but the SF project contains several source snapshots, so it should be possible to reconstruct at least some coarse history.

Assets are not free-as-in-freedom but are free-as-in-beer, so neither the "open" nor the "commercial" tag seems to fit. Maybe a new category is needed there?