### PR TITLE
Add Civic Nightmare

### DIFF
--- a/entries/civic_nightmare.md
+++ b/entries/civic_nightmare.md
@@ -1,0 +1,21 @@
+# Civic Nightmare
+
+- Home: https://github.com/Daniele-Cangi/civic-nightmare
+- State: mature
+- Play: https://daniele-cangi.github.io/civic-nightmare/
+- Download: https://github.com/Daniele-Cangi/civic-nightmare/releases
+- Platform: Web
+- Keyword: role playing, 2D, single-player, top-down
+- Code repository: https://github.com/Daniele-Cangi/civic-nightmare.git
+- Code language: GDScript
+- Code license: MIT
+- Code dependency: Godot
+- Assets license: Custom (no blanket asset license; media and narrative content are not covered by MIT; see https://github.com/Daniele-Cangi/civic-nightmare/blob/main/ASSET_NOTICE.md)
+- Developer: Daniele Cangi
+
+A satirical top-down role-playing game built with Godot 4.6 and playable in the browser.
+
+## Building
+
+- Build system: Godot
+- Build instruction: https://github.com/Daniele-Cangi/civic-nightmare/blob/main/CONTRIBUTING.md#getting-started


### PR DESCRIPTION
Adds a single OSGL entry for Civic Nightmare, a browser-playable Godot 4.6 role-playing game. The source code is MIT-licensed; the entry separately records that media and narrative content have no blanket asset license and links the project's ASSET_NOTICE.md. No generated files or indexes are changed.